### PR TITLE
Fix compiler warnings

### DIFF
--- a/i2csfp.c
+++ b/i2csfp.c
@@ -715,14 +715,14 @@ static int runbruteforce(int file, unsigned int start, int min, int max,
 static void exiterror(char * str)
 {
 	if (file >= 0) close(file);
-	fprintf(stderr, str);
+	fprintf(stderr, "%s", str);
 	exit(1);
 }
 
 static void exithelp(char * str)
 {
 	if (file >= 0) close(file);
-	fprintf(stderr, str);
+	fprintf(stderr, "%s", str);
 	help();
 	exit(1);
 }
@@ -891,8 +891,7 @@ static int gpio(int file, char * sfpname, char * gpioname, int boolval)
 
 	finddev("/sys/bus/gpio/devices", phandle, pinctrl, SIZEOFPATH);
 
-	printf(pinctrl);
-	printf(" TEST %x %x %x\n", phandle, pinnr, active);
+	printf("%s TEST %x %x %x\n", pinctrl, phandle, pinnr, active);
 
 	fd = open(pinctrl, O_RDWR | O_CLOEXEC);
 	if (fd < 0) return fd;
@@ -918,7 +917,7 @@ static int gpio(int file, char * sfpname, char * gpioname, int boolval)
 int main(int argc, char *argv[])
 {
 	char *end;
-	int busaddr, devad, dregister, value;
+	int busaddr, devad, dregister, value = 0;
 	int opt, res = 0, verify = 0;
 	const char *password = NULL;
 	const char *vendorname = NULL;


### PR DESCRIPTION
```
i2csfp.c: In function 'exiterror':
i2csfp.c:718:9: error: format not a string literal and no format arguments [-Werror=format-security]
  718 |         fprintf(stderr, str);
      |         ^~~~~~~
i2csfp.c: In function 'exithelp':
i2csfp.c:725:9: error: format not a string literal and no format arguments [-Werror=format-security]
  725 |         fprintf(stderr, str);
      |         ^~~~~~~
i2csfp.c: In function 'gpio':
i2csfp.c:894:16: error: format not a string literal and no format arguments [-Werror=format-security]
  894 |         printf(pinctrl);
      |                ^~~~~~~
i2csfp.c: In function 'main':
i2csfp.c:1010:33: warning: 'value' may be used uninitialized [-Wmaybe-uninitialized]
 1010 |                         else if (res != value) printf("Warning - data mismatch - wrote "
      |                                 ^
i2csfp.c:921:40: note: 'value' was declared here
  921 |         int busaddr, devad, dregister, value;
      |                                        ^~~~~
cc1: some warnings being treated as errors
```