### PR TITLE
skip 'module' entry in listsfps

### DIFF
--- a/i2csfp.c
+++ b/i2csfp.c
@@ -791,6 +791,7 @@ static void listsfps()
 		if (!strcmp(entry->d_name, "bind")) continue;
 		if (!strcmp(entry->d_name, "unbind")) continue;
 		if (!strcmp(entry->d_name, "uevent")) continue;
+		if (!strcmp(entry->d_name, "module")) continue;
 		printf("%s\n", entry->d_name);
 	}
 	closedir(dirpos);


### PR DESCRIPTION
```
root@bpi-r4:/sys/bus/platform/drivers/sfp# ls -l
--w-------    1 root     root          4096 Jun 16 12:56 bind
lrwxrwxrwx    1 root     root             0 Jun 16 12:56 module -> ../../../../module/sfp
lrwxrwxrwx    1 root     root             0 Jun 16 12:56 sfp1 -> ../../../../devices/platform/sfp1
lrwxrwxrwx    1 root     root             0 Jun 16 12:56 sfp2 -> ../../../../devices/platform/sfp2
--w-------    1 root     root          4096 Jun 16 12:56 uevent
--w-------    1 root     root          4096 Jun 16 12:56 unbind
```
Makes me wonder what would happen if we label an SFP slot named 'bind', 'module', 'uevent' or 'unbind' in DT...