### PR TITLE
fix incompatible function pointer types to fix GCC 15 build

### DIFF
--- a/i2csfp.c
+++ b/i2csfp.c
@@ -637,7 +637,7 @@ static int bfmod_2(int value)
 }
 
 static int bruteforcepart(int file, int value, bool check, int min, int max,
-			int (*bfread)(), int (*bfwrite)(), int (*bfmod)())
+			int (*bfread)(int), int (*bfwrite)(int,int), int (*bfmod)(int))
 {
 	unsigned int c,d;
 	int res;
@@ -673,7 +673,7 @@ static int bruteforcepart(int file, int value, bool check, int min, int max,
 }
 
 static int runbruteforce(int file, unsigned int start, int min, int max,
-			int (*bfread)(), int (*bfwrite)(), int (*bfmod)())
+			int (*bfread)(int), int (*bfwrite)(int,int), int (*bfmod)(int))
 {
 	unsigned int a,b;
 	int res, orig;


### PR DESCRIPTION
Fix the pointer types in signatures of 'bruteforcepart' and 'runbruteforce' to fix the following issue:

```
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c: In function 'bruteforcepart': /mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:651:31: error: too many arguments to function 'bfwrite'; expected 0, have 2
  651 |                         res = bfwrite(file, value);
      |                               ^~~~~~~ ~~~~
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:654:39: error: too many arguments to function 'bfread'; expected 0, have 1
  654 |                                 res = bfread(file);
      |                                       ^~~~~~ ~~~~
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:665:23: error: too many arguments to function 'bfread'; expected 0, have 1
  665 |                 res = bfread(file);
      |                       ^~~~~~ ~~~~
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c: In function 'runbruteforce':
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:684:16: error: too many arguments to function 'bfread'; expected 0, have 1
  684 |         orig = bfread(file);
      |                ^~~~~~ ~~~~
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:697:52: error: too many arguments to function 'bfmod'; expected 0, have 1
  697 |                         res = bruteforcepart(file, bfmod(orig), false, min, max, bfread, bfwrite, bfmod);
      |                                                    ^~~~~ ~~~~
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c: In function 'main':
/mnt/dev/jonas/openwrt/build_dir/target-mips_24kc_musl/i2csfp-2024.06.16~da2c7582/i2csfp.c:1112:75: error: passing argument 5 of 'runbruteforce' from incompatible pointer type [-Wincompatible-pointer-types]
 1112 |                         res = runbruteforce(file, password_hex, min, max, bfread_1, bfwrite_1, bfmod_1);
      |                                                                           ^~~~~~~~
      |                                                                           |
...
```

Cause of this issue is the incompatible types for bfread, bfwrite and bfmod between the function signatures of `bruteforcepart` and `runbruteforce` and what's passed to them in calls. This was probably a warning before, but compiling in OpenWrt with GCC 15 makes this errors.